### PR TITLE
Compatibility with PHP <5.4 which doesn't have array literals

### DIFF
--- a/local-shortcodes.php
+++ b/local-shortcodes.php
@@ -2,7 +2,7 @@
 /**
  *
  * Local Shortcodes
- * @version  0.0.2
+ * @version  0.0.3
  * 
  * Adapted from WordPress core:
  * https://github.com/WordPress/WordPress/blob/master/wp-includes/shortcodes.php
@@ -270,7 +270,7 @@ function do_local_shortcode_with($global_tag, $content, $post) {
 	
 	// convert arrays to what preg_replace_callback uses
 	// because that is what do_local_shortcode_tag expects
-	$new_matches = [];
+	$new_matches = array();
 	foreach ( $match_all as $m_key => $matches ) {
 		foreach ( $matches as $match_key => $match ) {
 			// assemble match array

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ### Local shortcodes
 
-Register and run shortcodes within a given namespace.
+Register and run shortcodes within a local namespace.
 
 This avoids competing with shortcode names used by other themes and plugins.
 
@@ -59,7 +59,10 @@ remove_all_local_shortcodes('context');
 ###### Inside parent shortcode
 
 ```
+// Register parent shortcode in global namespace
 add_shortcode('parent', 'parent_shortcode');
+
+// Register child shortcode in local namespace
 add_local_shortcode('parent', 'child', 'child_shortcode');
 
 function parent_shortcode( $atts, $content ) {
@@ -69,4 +72,9 @@ function parent_shortcode( $atts, $content ) {
   return do_local_shortcode('parent', $content);
 }
 
+function child_shortcode( $atts, $content ) {
+
+  ...Do stuff here..
+
+}
 ```


### PR DESCRIPTION
Hello, I recently included local shortcodes in a plugin, and a user told me it throws an error on an older version of PHP. It was due to one line using a shorthand `[]` to create an array. So this commit fixes it.